### PR TITLE
Improve memory when flattening maps 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/octarinesec/secret-detector
 
-go 1.18
+go 1.21
 
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible

--- a/pkg/transformers/helpers/flatten.go
+++ b/pkg/transformers/helpers/flatten.go
@@ -7,7 +7,7 @@ import (
 
 func Flatten(in interface{}) map[string]string {
 	out := make(map[string]string)
-	initial := make([]byte, 0, 64)
+	initial := make([]byte, 0, 64) // We sacrifice some memory but avoid expanding the initial buffer since most keys are not 2-10 runes long
 	flattenRecursive(&initial, in, out)
 	return out
 }

--- a/pkg/transformers/helpers/flatten.go
+++ b/pkg/transformers/helpers/flatten.go
@@ -21,7 +21,7 @@ func flattenRecursive(prefixAcc *[]byte, in any, out map[string]string) {
 	// Note: if prefixAcc is []byte instead of *[]byte, then the slice header is copied on each call
 	// there is a chance that the byte array might be moved due to a required resize
 	// and then the caller's slice will no longer point to the same array, hence keeping both in memory for some time
-	// Which is why we use a pointer in the recursion and all calls should opearate on the same slice header
+	// Which is why we use a pointer in the recursion and all calls should operate on the same slice header
 	prefix := *prefixAcc
 
 	if in == nil {
@@ -64,23 +64,5 @@ func flattenRecursive(prefixAcc *[]byte, in any, out map[string]string) {
 		out[string(prefix)] = strconv.FormatBool(obj)
 	default:
 		out[string(prefix)] = fmt.Sprint(obj)
-	}
-}
-
-func flattenRecursive2(prefix string, in interface{}, out map[string]string) {
-	switch obj := in.(type) {
-	case map[string]interface{}:
-		if len(prefix) > 0 {
-			prefix += "."
-		}
-		for k, v := range obj {
-			flattenRecursive2(prefix+k, v, out)
-		}
-	case []interface{}:
-		for elemIndex, elem := range obj {
-			flattenRecursive2(fmt.Sprintf("%v[%v]", prefix, elemIndex), elem, out)
-		}
-	default:
-		out[prefix] = fmt.Sprint(obj)
 	}
 }

--- a/pkg/transformers/helpers/flatten.go
+++ b/pkg/transformers/helpers/flatten.go
@@ -1,26 +1,84 @@
 package helpers
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 func Flatten(in interface{}) map[string]string {
 	out := make(map[string]string)
-	flattenRecursive("", in, out)
+	initial := make([]byte, 0, 64)
+	flattenRecursive(&initial, in, out)
 	return out
 }
 
-// modified from https://stackoverflow.com/a/64420075/133665
-func flattenRecursive(prefix string, in interface{}, out map[string]string) {
+// flattenRecursive flattens a JSON object into a map where each parent array or object for a field is appended to the its new key
+// For example { "a" : { "b" : "c" } } should become { "a.b" : "c" }
+// it is assumed that the root call is made with a JSON object and not a raw value or array
+//
+// prefixAcc keeps the prefix so far in a slice buffer
+func flattenRecursive(prefixAcc *[]byte, in any, out map[string]string) {
+	// Note: if prefixAcc is []byte instead of *[]byte, then the slice header is copied on each call
+	// there is a chance that the byte array might be moved due to a required resize
+	// and then the caller's slice will no longer point to the same array, hence keeping both in memory for some time
+	// Which is why we use a pointer in the recursion and all calls should opearate on the same slice header
+	prefix := *prefixAcc
+
+	if in == nil {
+		out[string(prefix)] = ""
+		return
+	}
+
+	switch obj := in.(type) {
+	case map[string]any:
+		if len(prefix) > 0 {
+			prefix = append(prefix, '.')
+		}
+		for k, v := range obj {
+			prefix = append(prefix, []byte(k)...)
+			flattenRecursive(&prefix, v, out)
+			prefix = prefix[:len(prefix)-len(k)]
+		}
+		if len(prefix) > 0 { // Remove the "." that we added
+			prefix = prefix[:len(prefix)-1]
+		}
+	case []any:
+		prefix = append(prefix, '[')
+		for elemIndex := range obj {
+			s := strconv.Itoa(elemIndex)
+			prefix = append(prefix, []byte(s)...)
+			prefix = append(prefix, ']')
+			flattenRecursive(&prefix, obj[elemIndex], out)
+			prefix = prefix[:len(prefix)-len(s)-1] // Remove "index]"
+		}
+		prefix = prefix[:len(prefix)-1] // Remove the '['
+	case string:
+		out[string(prefix)] = obj
+	case int:
+		out[string(prefix)] = strconv.Itoa(obj)
+	case int64:
+		out[string(prefix)] = strconv.FormatInt(obj, 10)
+	case uint64:
+		out[string(prefix)] = strconv.FormatUint(obj, 10)
+	case bool:
+		out[string(prefix)] = strconv.FormatBool(obj)
+	default:
+		out[string(prefix)] = fmt.Sprint(obj)
+	}
+}
+
+func flattenRecursive2(prefix string, in interface{}, out map[string]string) {
 	switch obj := in.(type) {
 	case map[string]interface{}:
 		if len(prefix) > 0 {
 			prefix += "."
 		}
 		for k, v := range obj {
-			flattenRecursive(prefix+k, v, out)
+			flattenRecursive2(prefix+k, v, out)
 		}
 	case []interface{}:
 		for elemIndex, elem := range obj {
-			flattenRecursive(fmt.Sprintf("%v[%v]", prefix, elemIndex), elem, out)
+			flattenRecursive2(fmt.Sprintf("%v[%v]", prefix, elemIndex), elem, out)
 		}
 	default:
 		out[prefix] = fmt.Sprint(obj)

--- a/pkg/transformers/helpers/flatten_test.go
+++ b/pkg/transformers/helpers/flatten_test.go
@@ -1,0 +1,40 @@
+package helpers
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var (
+	j = `{
+			"pure_value": 123, 
+			"array_of_objects": [ { "id": 1 }, {"id": 2, "another_value": true }],
+			"subobject": { "subarray": [1, 2, 3], "second_level_object":  { "string": "str", "number": 123.1 } },
+			"null": null
+		}`
+)
+
+func TestFlattenRecursive(t *testing.T) {
+	var jsonMap map[string]any
+	err := json.Unmarshal([]byte(j), &jsonMap)
+
+	assert.NoError(t, err)
+
+	flattened := Flatten(jsonMap)
+
+	assert.Contains(t, flattened, "pure_value")
+	assert.Equal(t, "123", flattened["pure_value"])
+	assert.Contains(t, flattened, "null")
+	assert.Equal(t, "", flattened["null"])
+	assert.Contains(t, flattened, "array_of_objects[0].id")
+	assert.Equal(t, "1", flattened["array_of_objects[0].id"])
+	assert.Contains(t, flattened, "array_of_objects[1].another_value")
+	assert.Equal(t, "true", flattened["array_of_objects[1].another_value"])
+	assert.Contains(t, flattened, "subobject.subarray[2]")
+	assert.Equal(t, "3", flattened["subobject.subarray[2]"])
+	assert.Contains(t, flattened, "subobject.second_level_object.string")
+	assert.Equal(t, "str", flattened["subobject.second_level_object.string"])
+	assert.Contains(t, flattened, "subobject.second_level_object.number")
+	assert.Equal(t, "123.1", flattened["subobject.second_level_object.number"])
+}


### PR DESCRIPTION
The json flattening operation (used in JSON/YAML files) was doing a lot of allocations due to temporary strings. This removes the temporary strings and uses an ongoing buffer to compute the keys. 

Improves memory consumption by 15-20% in benchmark with 29MB file and slightly improves processing time - see benchmark results below. 

```
goos: darwin
goarch: amd64
pkg: github.com/octarinesec/secret-detector/pkg/transformers/helpers
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkFlattenRecursiveNew-16               30         304957423 ns/op        103321812 B/op    616315 allocs/op
BenchmarkFlattenRecursiveOld-16                30         411418986 ns/op        129355625 B/op   1265458 allocs/op
PASS
ok      github.com/octarinesec/secret-detector/pkg/transformers/helpers 24.907s
```